### PR TITLE
Add support for synchronous produce

### DIFF
--- a/pixy/httpapi_test.go
+++ b/pixy/httpapi_test.go
@@ -160,6 +160,11 @@ func (s *HTTPAPISuite) TestRequestAfterStop(c *C) {
 	c.Assert(err.Error(), Equals, "Post http://_/topics/httpapi-test?key=2: EOF")
 }
 
+func (s *HTTPAPISuite) Produce(topic string, key, message sarama.Encoder) error {
+	s.produced = append(s.produced, &production{topic, key, message})
+	return nil
+}
+
 func (s *HTTPAPISuite) AsyncProduce(topic string, key, message sarama.Encoder) {
 	s.produced = append(s.produced, &production{topic, key, message})
 }


### PR DESCRIPTION
Some users may want to have guarantees that produced messages have indeed been submitted to Kafka. So **sync** parameter was introduced that if specified make the HTTP produce request block until the message is submitted to all in-sync replicas, or after the configured number of retries and back offs the proxy gave up. Either way the result is returned as an HTTP status.