### PR TITLE
Add offset get/set HTTP API methods (fixes #14)

### DIFF
--- a/pixy/admin.go
+++ b/pixy/admin.go
@@ -1,0 +1,201 @@
+package pixy
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/mailgun/kafka-pixy/Godeps/_workspace/src/github.com/mailgun/sarama"
+)
+
+type (
+	ErrAdminSetup    error
+	ErrAdminKafkaReq struct {
+		err  error
+		desc string
+	}
+)
+
+func NewErrAdminKafkaReq(err error, format string, v ...interface{}) ErrAdminKafkaReq {
+	return ErrAdminKafkaReq{err, fmt.Sprintf(format, v...)}
+}
+
+func (e ErrAdminKafkaReq) Error() string {
+	return fmt.Sprintf("%s, err=(%s)", e.desc, e.err)
+}
+
+func (e ErrAdminKafkaReq) Cause() error {
+	return e.err
+}
+
+const (
+	ProtocolVer1 = 1 // Supported by Kafka v0.8.2 and later
+)
+
+// Admin provides methods to perform miscellaneous administrative operations
+// on the Kafka cluster.
+type Admin struct {
+	kafkaClient sarama.Client
+}
+
+// SpawnAdmin creates an `Admin` instance with the specified configuration and
+// starts internal goroutines to support its operation.
+func SpawnAdmin(config *Config) (*Admin, error) {
+	kafkaClient, err := sarama.NewClient(config.Kafka.SeedPeers, config.saramaConfig())
+	if err != nil {
+		return nil, ErrAdminSetup(fmt.Errorf("failed to create sarama.Client: err=(%v)", err))
+	}
+	a := Admin{kafkaClient: kafkaClient}
+	return &a, nil
+}
+
+// Stop gracefully terminates internal goroutines.
+func (a *Admin) Stop() {
+	a.kafkaClient.Close()
+}
+
+type PartitionOffset struct {
+	Partition int32
+	Range     struct {
+		Begin int64
+		End   int64
+	}
+	Offset   int64
+	Metadata string
+}
+
+type indexedPartition struct {
+	index     int
+	partition int32
+}
+
+// GetGroupOffsets for every partition of the specified topic it returns the
+// current offset range along with the latest offset and metadata committed by
+// the specified consumer group.
+func (a *Admin) GetGroupOffsets(group, topic string) ([]PartitionOffset, error) {
+	var err error
+	partitions, err := a.kafkaClient.Partitions(topic)
+	if err != nil {
+		return nil, NewErrAdminKafkaReq(err, "failed to get topic partitions")
+	}
+
+	// Figure out distribution of partitions among brokers.
+	brokerToPartitions := make(map[*sarama.Broker][]indexedPartition)
+	for i, p := range partitions {
+		broker, err := a.kafkaClient.Leader(topic, p)
+		if err != nil {
+			return nil, NewErrAdminKafkaReq(err, "failed to get partition leader: partition=%d", p)
+		}
+		brokerToPartitions[broker] = append(brokerToPartitions[broker], indexedPartition{i, p})
+	}
+
+	// Query brokers for the oldest and newest offsets of the partitions that
+	// they are leaders for.
+	offsets := make([]PartitionOffset, len(partitions))
+	var wg sync.WaitGroup
+	errorsCh := make(chan ErrAdminKafkaReq, len(brokerToPartitions))
+	for broker, brokerPartitions := range brokerToPartitions {
+		broker, brokerPartitions := broker, brokerPartitions
+		var reqNewest sarama.OffsetRequest
+		var reqOldest sarama.OffsetRequest
+		for _, p := range brokerPartitions {
+			reqNewest.AddBlock(topic, p.partition, sarama.OffsetNewest, 1)
+			reqOldest.AddBlock(topic, p.partition, sarama.OffsetOldest, 1)
+		}
+		spawn(&wg, func() {
+			resOldest, err := broker.GetAvailableOffsets(&reqOldest)
+			if err != nil {
+				errorsCh <- NewErrAdminKafkaReq(err, "failed to fetch oldest offset: broker=%v", broker.ID())
+				return
+			}
+			resNewest, err := broker.GetAvailableOffsets(&reqNewest)
+			if err != nil {
+				errorsCh <- NewErrAdminKafkaReq(err, "failed to fetch newest offset: broker=%v", broker.ID())
+				return
+			}
+			for _, xp := range brokerPartitions {
+				begin, err := getOffsetResult(resOldest, topic, xp.partition)
+				if err != nil {
+					errorsCh <- NewErrAdminKafkaReq(err, "failed to fetch oldest offset: broker=%v", broker.ID())
+					return
+				}
+				end, err := getOffsetResult(resNewest, topic, xp.partition)
+				if err != nil {
+					errorsCh <- NewErrAdminKafkaReq(err, "failed to fetch newest offset: broker=%v", broker.ID())
+					return
+				}
+				offsets[xp.index].Partition = xp.partition
+				offsets[xp.index].Range.Begin = begin
+				offsets[xp.index].Range.End = end
+			}
+		})
+	}
+	wg.Wait()
+	// If we failed to get offset range for at least one of the partitions then
+	// return the first error that was reported.
+	close(errorsCh)
+	if err, ok := <-errorsCh; ok {
+		return nil, err
+	}
+
+	// Fetch the last committed offsets for all partitions of the group/topic.
+	coordinator, err := a.kafkaClient.Coordinator(group)
+	if err != nil {
+		return nil, NewErrAdminKafkaReq(err, "failed to get coordinator")
+	}
+	req := sarama.OffsetFetchRequest{ConsumerGroup: group, Version: ProtocolVer1}
+	for _, p := range partitions {
+		req.AddPartition(topic, p)
+	}
+	res, err := coordinator.FetchOffset(&req)
+	if err != nil {
+		return nil, NewErrAdminKafkaReq(err, "failed to fetch offsets")
+	}
+	for i, p := range partitions {
+		block := res.GetBlock(topic, p)
+		if block == nil {
+			return nil, NewErrAdminKafkaReq(nil, "offset block is missing: partition=%d", p)
+		}
+		offsets[i].Offset = block.Offset
+		offsets[i].Metadata = block.Metadata
+	}
+
+	return offsets, nil
+}
+
+// SetGroupOffsets commits specific offset values along with metadata for a list
+// of partitions of a particular topic on behalf of the specified group.
+func (a *Admin) SetGroupOffsets(group, topic string, offsets []PartitionOffset) error {
+	coordinator, err := a.kafkaClient.Coordinator(group)
+	if err != nil {
+		return NewErrAdminKafkaReq(err, "failed to get coordinator")
+	}
+
+	req := sarama.OffsetCommitRequest{ConsumerGroup: group, Version: ProtocolVer1}
+	for _, po := range offsets {
+		req.AddBlock(topic, po.Partition, po.Offset, sarama.ReceiveTime, po.Metadata)
+	}
+	res, err := coordinator.CommitOffset(&req)
+	if err != nil {
+		return NewErrAdminKafkaReq(err, "failed to commit offsets")
+	}
+	for p, err := range res.Errors[topic] {
+		if err != sarama.ErrNoError {
+			return NewErrAdminKafkaReq(err, "failed to commit offset: partition=%d", p)
+		}
+	}
+	return nil
+}
+
+func getOffsetResult(res *sarama.OffsetResponse, topic string, partition int32) (int64, error) {
+	block := res.GetBlock(topic, partition)
+	if block == nil {
+		return 0, fmt.Errorf("%s/%d: no data", topic, partition)
+	}
+	if block.Err != sarama.ErrNoError {
+		return 0, fmt.Errorf("%s/%d: fetch error: (%v)", topic, partition, block.Err)
+	}
+	if len(block.Offsets) < 1 {
+		return 0, fmt.Errorf("%s/%d: no offset", topic, partition)
+	}
+	return block.Offsets[0], nil
+}

--- a/pixy/admin_test.go
+++ b/pixy/admin_test.go
@@ -1,0 +1,86 @@
+package pixy
+
+import (
+	"strconv"
+
+	. "github.com/mailgun/kafka-pixy/Godeps/_workspace/src/gopkg.in/check.v1"
+)
+
+type AdminSuite struct {
+	config *Config
+}
+
+var _ = Suite(&AdminSuite{})
+
+func (s *AdminSuite) SetUpSuite(c *C) {
+	InitTestLog()
+	s.config = NewConfig()
+	s.config.ClientID = "producer"
+	s.config.Kafka.SeedPeers = testKafkaPeers
+}
+
+// The end offset of partition ranges is properly reflects the number of
+// messages produced since the previous check.
+func (s *AdminSuite) TestGetOffsetsAfterProduce(c *C) {
+	// Given
+	keyToCount := make(map[string]int, 64)
+	for i := 0; i < 64; i++ {
+		keyToCount[strconv.Itoa(i)] = i
+	}
+	GenMessages(c, "get_offsets", "test.64", keyToCount)
+
+	a, err := SpawnAdmin(s.config)
+	c.Assert(err, IsNil)
+	offsetsBefore, err := a.GetGroupOffsets("foo", "test.64")
+	c.Assert(err, IsNil)
+	GenMessages(c, "get_offsets", "test.64", keyToCount)
+
+	// When
+	offsetsAfter, err := a.GetGroupOffsets("foo", "test.64")
+	c.Assert(err, IsNil)
+
+	// Then
+	rangeEndDiffs := []int{
+		0, 75, 3, 0, 57, 0, 0, 8, 58, 6, 30, 59, 0, 75, 63, 0, 48, 37, 49, 0,
+		75, 2, 0, 51, 0, 0, 0, 79, 1, 33, 61, 39, 75, 62, 0, 4, 36, 0, 0, 79,
+		61, 28, 53, 35, 18, 0, 79, 0, 32, 63, 38, 0, 9, 59, 7, 31, 14, 0, 79, 60,
+		29, 55, 34, 67,
+	}
+	for i := 0; i < 64; i++ {
+		actualDiff := int(offsetsAfter[i].Range.End - offsetsBefore[i].Range.End)
+		c.Assert(actualDiff, Equals, rangeEndDiffs[i])
+	}
+	a.Stop()
+}
+
+// It is possible to set offsets for only a subset of group/topic partitions.
+func (s *AdminSuite) TestSetOffsetsPartialUpdate(c *C) {
+	// Given
+	a, err := SpawnAdmin(s.config)
+	c.Assert(err, IsNil)
+	a.SetGroupOffsets("foo", "test.4", []PartitionOffset{
+		{Partition: 0, Offset: 1001, Metadata: "A1"},
+		{Partition: 1, Offset: 1002, Metadata: "A2"},
+		{Partition: 2, Offset: 1003, Metadata: "A3"},
+		{Partition: 3, Offset: 1004, Metadata: "A4"},
+	})
+
+	// When
+	a.SetGroupOffsets("foo", "test.4", []PartitionOffset{
+		{Partition: 0, Offset: 2001, Metadata: "B1"},
+		{Partition: 3, Offset: 2004, Metadata: "B4"},
+	})
+
+	// Then
+	offsets, err := a.GetGroupOffsets("foo", "test.4")
+	c.Assert(offsets[0].Offset, Equals, int64(2001))
+	c.Assert(offsets[1].Offset, Equals, int64(1002))
+	c.Assert(offsets[2].Offset, Equals, int64(1003))
+	c.Assert(offsets[3].Offset, Equals, int64(2004))
+	c.Assert(offsets[0].Metadata, Equals, "B1")
+	c.Assert(offsets[1].Metadata, Equals, "A2")
+	c.Assert(offsets[2].Metadata, Equals, "A3")
+	c.Assert(offsets[3].Metadata, Equals, "B4")
+
+	a.Stop()
+}

--- a/pixy/consumer_test.go
+++ b/pixy/consumer_test.go
@@ -101,7 +101,7 @@ func (s *SmartConsumerSuite) TestSinglePartitionTopic(c *C) {
 	ResetOffsets(c, "group-1", "test.1")
 	produced := GenMessages(c, "single", "test.1", map[string]int{"": 3})
 
-	sc, err := SpawnSmartConsumer(s.newConfig("consumer-1"))
+	sc, err := SpawnSmartConsumer(NewTestConfig("consumer-1"))
 	c.Assert(err, IsNil)
 
 	// When/Then
@@ -118,7 +118,7 @@ func (s *SmartConsumerSuite) TestSequentialConsume(c *C) {
 	ResetOffsets(c, "group-1", "test.1")
 	produced := GenMessages(c, "sequencial", "test.1", map[string]int{"": 3})
 
-	config := s.newConfig("consumer-1")
+	config := NewTestConfig("consumer-1")
 	sc1, err := SpawnSmartConsumer(config)
 	c.Assert(err, IsNil)
 	log.Infof("*** GIVEN 1")
@@ -147,7 +147,7 @@ func (s *SmartConsumerSuite) TestMultiPartitionTopic(c *C) {
 	GenMessages(c, "multi", "test.4", map[string]int{"A": 100, "B": 100})
 
 	log.Infof("*** GIVEN 1")
-	sc, err := SpawnSmartConsumer(s.newConfig("consumer-1"))
+	sc, err := SpawnSmartConsumer(NewTestConfig("consumer-1"))
 	c.Assert(err, IsNil)
 
 	// When: exactly one half of all produced events is consumed.
@@ -174,7 +174,7 @@ func (s *SmartConsumerSuite) TestTooFewPartitions(c *C) {
 	ResetOffsets(c, "group-1", "test.1")
 	produced := GenMessages(c, "few", "test.1", map[string]int{"": 3})
 
-	sc1, err := SpawnSmartConsumer(s.newConfig("consumer-1"))
+	sc1, err := SpawnSmartConsumer(NewTestConfig("consumer-1"))
 	c.Assert(err, IsNil)
 	log.Infof("*** GIVEN 1")
 	// Consume first message to make `consumer-1` subscribe for `test.1`
@@ -183,7 +183,7 @@ func (s *SmartConsumerSuite) TestTooFewPartitions(c *C) {
 
 	// When:
 	log.Infof("*** WHEN")
-	sc2, err := SpawnSmartConsumer(s.newConfig("consumer-2"))
+	sc2, err := SpawnSmartConsumer(NewTestConfig("consumer-2"))
 	c.Assert(err, IsNil)
 	_, err = sc2.Consume("group-1", "test.1")
 
@@ -207,7 +207,7 @@ func (s *SmartConsumerSuite) TestRebalanceOnJoin(c *C) {
 	ResetOffsets(c, "group-1", "test.4")
 	GenMessages(c, "join", "test.4", map[string]int{"A": 10, "B": 10})
 
-	sc1, err := SpawnSmartConsumer(s.newConfig("consumer-1"))
+	sc1, err := SpawnSmartConsumer(NewTestConfig("consumer-1"))
 	c.Assert(err, IsNil)
 
 	// Consume the first message to make the consumer join the group and
@@ -227,7 +227,7 @@ func (s *SmartConsumerSuite) TestRebalanceOnJoin(c *C) {
 
 	// When: another consumer joins the group rebalancing occurs.
 	log.Infof("*** WHEN")
-	sc2, err := SpawnSmartConsumer(s.newConfig("consumer-2"))
+	sc2, err := SpawnSmartConsumer(NewTestConfig("consumer-2"))
 	c.Assert(err, IsNil)
 
 	// Then:
@@ -259,7 +259,7 @@ func (s *SmartConsumerSuite) TestRebalanceOnLeave(c *C) {
 	var err error
 	consumers := make([]*SmartConsumer, 3)
 	for i := 0; i < 3; i++ {
-		consumers[i], err = SpawnSmartConsumer(s.newConfig(fmt.Sprintf("consumer-%d", i)))
+		consumers[i], err = SpawnSmartConsumer(NewTestConfig(fmt.Sprintf("consumer-%d", i)))
 		c.Assert(err, IsNil)
 	}
 	log.Infof("*** GIVEN 1")
@@ -330,10 +330,10 @@ func (s *SmartConsumerSuite) TestRebalanceOnTimeout(c *C) {
 	ResetOffsets(c, "group-1", "test.4")
 	GenMessages(c, "join", "test.4", map[string]int{"A": 10, "B": 10})
 
-	sc1, err := SpawnSmartConsumer(s.newConfig("consumer-1"))
+	sc1, err := SpawnSmartConsumer(NewTestConfig("consumer-1"))
 	c.Assert(err, IsNil)
 
-	config2 := s.newConfig("consumer-2")
+	config2 := NewTestConfig("consumer-2")
 	config2.Consumer.RegistrationTimeout = 300 * time.Millisecond
 	sc2, err := SpawnSmartConsumer(config2)
 	c.Assert(err, IsNil)
@@ -391,7 +391,7 @@ func (s *SmartConsumerSuite) TestBufferOverflowError(c *C) {
 	ResetOffsets(c, "group-1", "test.1")
 	GenMessages(c, "join", "test.1", map[string]int{"A": 30})
 
-	config := s.newConfig("consumer-1")
+	config := NewTestConfig("consumer-1")
 	config.ChannelBufferSize = 1
 	sc, err := SpawnSmartConsumer(config)
 	c.Assert(err, IsNil)
@@ -431,7 +431,7 @@ func (s *SmartConsumerSuite) TestRequestDuringTimeout(c *C) {
 	ResetOffsets(c, "group-1", "test.4")
 	GenMessages(c, "join", "test.4", map[string]int{"A": 30})
 
-	config := s.newConfig("consumer-1")
+	config := NewTestConfig("consumer-1")
 	config.Consumer.RegistrationTimeout = 200 * time.Millisecond
 	config.ChannelBufferSize = 1
 	sc, err := SpawnSmartConsumer(config)
@@ -457,7 +457,7 @@ func (s *SmartConsumerSuite) TestRequestDuringTimeout(c *C) {
 // request times out after `Config.Consumer.LongPollingTimeout`.
 func (s *SmartConsumerSuite) TestInvalidTopic(c *C) {
 	// Given
-	config := s.newConfig("consumer-1")
+	config := NewTestConfig("consumer-1")
 	config.Consumer.LongPollingTimeout = 1 * time.Second
 	sc, err := SpawnSmartConsumer(config)
 	c.Assert(err, IsNil)
@@ -472,18 +472,6 @@ func (s *SmartConsumerSuite) TestInvalidTopic(c *C) {
 	c.Assert(consMsg, IsNil)
 
 	sc.Stop()
-}
-
-func (s *SmartConsumerSuite) newConfig(clientID string) *Config {
-	config := NewConfig()
-	config.ClientID = clientID
-	config.Kafka.SeedPeers = testKafkaPeers
-	config.ZooKeeper.SeedPeers = testZookeeperPeers
-	config.Consumer.LongPollingTimeout = 3000 * time.Millisecond
-	config.Consumer.BackOffTimeout = 100 * time.Millisecond
-	config.Consumer.RebalanceDelay = 100 * time.Millisecond
-	config.testing.firstMessageFetchedCh = make(chan *exclusiveConsumer, 100)
-	return config
 }
 
 func (s *SmartConsumerSuite) assertMsg(c *C, consMsg *sarama.ConsumerMessage, prodMsg *sarama.ProducerMessage) {

--- a/pixy/httpapi.go
+++ b/pixy/httpapi.go
@@ -29,25 +29,24 @@ const (
 	ParamGroup = "group"
 )
 
+var (
+	EmptyResponse = map[string]interface{}{}
+)
+
 type HTTPAPIServer struct {
 	addr       string
 	listener   net.Listener
 	httpServer *manners.GracefulServer
 	producer   *GracefulProducer
 	consumer   *SmartConsumer
+	admin      *Admin
 	errorCh    chan error
 }
 
 // NewHTTPAPIServer creates an HTTP server instance that will accept API
 // requests specified network/address and forwards them to the associated
 // Kafka client.
-func NewHTTPAPIServer(network, addr string, producer *GracefulProducer, consumer *SmartConsumer) (*HTTPAPIServer, error) {
-	if producer == nil {
-		return nil, fmt.Errorf("producer must be specified")
-	}
-	if consumer == nil {
-		return nil, fmt.Errorf("consumer must be specified")
-	}
+func NewHTTPAPIServer(network, addr string, producer *GracefulProducer, consumer *SmartConsumer, admin *Admin) (*HTTPAPIServer, error) {
 	// Start listening on the specified unix domain socket address.
 	listener, err := net.Listen(network, addr)
 	if err != nil {
@@ -62,6 +61,7 @@ func NewHTTPAPIServer(network, addr string, producer *GracefulProducer, consumer
 		httpServer: httpServer,
 		producer:   producer,
 		consumer:   consumer,
+		admin:      admin,
 		errorCh:    make(chan error, 1),
 	}
 	// Configure the API request handlers.
@@ -72,6 +72,10 @@ func NewHTTPAPIServer(network, addr string, producer *GracefulProducer, consumer
 	// TODO deprecated endpoint, use `/topics/{topic}/messages` instead.
 	router.HandleFunc(fmt.Sprintf("/topics/{%s}", ParamTopic),
 		as.handleProduce).Methods("POST")
+	router.HandleFunc(fmt.Sprintf("/topics/{%s}/offsets", ParamTopic),
+		as.handleGetOffsets).Methods("GET")
+	router.HandleFunc(fmt.Sprintf("/topics/{%s}/offsets", ParamTopic),
+		as.handleSetOffsets).Methods("POST")
 	return as, nil
 }
 
@@ -139,7 +143,7 @@ func (as *HTTPAPIServer) handleProduce(w http.ResponseWriter, r *http.Request) {
 	// Asynchronously submit the message to the Kafka cluster.
 	if !isSync {
 		as.producer.AsyncProduce(topic, toEncoderPreservingNil(key), sarama.StringEncoder(message))
-		respondWithJSON(w, http.StatusOK, map[string]string{})
+		respondWithJSON(w, http.StatusOK, EmptyResponse)
 		return
 	}
 
@@ -167,15 +171,13 @@ func (as *HTTPAPIServer) handleConsume(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	topic := mux.Vars(r)[ParamTopic]
-	r.ParseForm()
-	groups := r.Form[ParamGroup]
-	if len(groups) != 1 {
-		errorText := fmt.Sprintf("One consumer group is expected, but %d provided", len(groups))
-		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{errorText})
+	group, err := getGroupParam(r)
+	if err != nil {
+		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{err.Error()})
 		return
 	}
 
-	consMsg, err := as.consumer.Consume(groups[0], topic)
+	consMsg, err := as.consumer.Consume(group, topic)
 	if err != nil {
 		var status int
 		switch err.(type) {
@@ -198,6 +200,83 @@ func (as *HTTPAPIServer) handleConsume(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleGetOffsets is an HTTP request handler for `GET /topic/{topic}/offsets`
+func (as *HTTPAPIServer) handleGetOffsets(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	topic := mux.Vars(r)[ParamTopic]
+	group, err := getGroupParam(r)
+	if err != nil {
+		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{err.Error()})
+		return
+	}
+
+	partitionOffsets, err := as.admin.GetGroupOffsets(group, topic)
+	if err != nil {
+		if err, ok := err.(ErrAdminKafkaReq); ok && err.Cause() == sarama.ErrUnknownTopicOrPartition {
+			respondWithJSON(w, http.StatusNotFound, errorHTTPResponse{"Unknown topic"})
+			return
+		}
+		respondWithJSON(w, http.StatusInternalServerError, errorHTTPResponse{err.Error()})
+		return
+	}
+
+	partitionOffsetView := make([]partitionOffsetView, len(partitionOffsets))
+	for i, po := range partitionOffsets {
+		partitionOffsetView[i].Partition = po.Partition
+		partitionOffsetView[i].Range.Begin = po.Range.Begin
+		partitionOffsetView[i].Range.End = po.Range.End
+		partitionOffsetView[i].Offset = po.Offset
+		partitionOffsetView[i].Metadata = po.Metadata
+	}
+	respondWithJSON(w, http.StatusOK, partitionOffsetView)
+}
+
+// handleGetOffsets is an HTTP request handler for `POST /topic/{topic}/offsets`
+func (as *HTTPAPIServer) handleSetOffsets(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	topic := mux.Vars(r)[ParamTopic]
+	group, err := getGroupParam(r)
+	if err != nil {
+		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{err.Error()})
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		errorText := fmt.Sprintf("Failed to read the request: cause=(%v)", err)
+		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{errorText})
+		return
+	}
+
+	var partitionOffsetViews []partitionOffsetView
+	if err := json.Unmarshal(body, &partitionOffsetViews); err != nil {
+		errorText := fmt.Sprintf("Failed to parse the request: cause=(%v)", err)
+		respondWithJSON(w, http.StatusBadRequest, errorHTTPResponse{errorText})
+		return
+	}
+
+	partitionOffsets := make([]PartitionOffset, len(partitionOffsetViews))
+	for i, pov := range partitionOffsetViews {
+		partitionOffsets[i].Partition = pov.Partition
+		partitionOffsets[i].Offset = pov.Offset
+		partitionOffsets[i].Metadata = pov.Metadata
+	}
+
+	err = as.admin.SetGroupOffsets(group, topic, partitionOffsets)
+	if err != nil {
+		if err, ok := err.(ErrAdminKafkaReq); ok && err.Cause() == sarama.ErrUnknownTopicOrPartition {
+			respondWithJSON(w, http.StatusNotFound, errorHTTPResponse{"Unknown topic"})
+			return
+		}
+		respondWithJSON(w, http.StatusInternalServerError, errorHTTPResponse{err.Error()})
+		return
+	}
+
+	respondWithJSON(w, http.StatusOK, EmptyResponse)
+}
+
 type produceHTTPResponse struct {
 	Partition int32 `json:"partition"`
 	Offset    int64 `json:"offset"`
@@ -208,6 +287,16 @@ type consumeHTTPResponse struct {
 	Value     []byte `json:"value"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
+}
+
+type partitionOffsetView struct {
+	Partition int32 `json:"partition"`
+	Range     struct {
+		Begin int64 `json:"begin"`
+		End   int64 `json:"end"`
+	} `json:"range"`
+	Offset   int64  `json:"offset"`
+	Metadata string `json:"metadata"`
 }
 
 type errorHTTPResponse struct {
@@ -241,4 +330,13 @@ func respondWithJSON(w http.ResponseWriter, status int, body interface{}) {
 	if _, err := w.Write(encodedRes); err != nil {
 		log.Errorf("Failed to send HTTP reponse: status=%d, body=%v, reason=%v", status, body, err)
 	}
+}
+
+func getGroupParam(r *http.Request) (string, error) {
+	r.ParseForm()
+	groups := r.Form[ParamGroup]
+	if len(groups) != 1 {
+		return "", fmt.Errorf("One consumer group is expected, but %d provided", len(groups))
+	}
+	return groups[0], nil
 }


### PR DESCRIPTION
This PR add two HTTP API methods that allow inspect/update committed offsets for a particular consumer group:
 * `GET /topics/{topic}/offsets?group={group}` - returns a list of committed offsets for `group`/`topic`.
 * `POST /topics/{topic}/offsets?group={group}` - updates committed offsets for `group`/`topic`. The body of the request should be a JSON list of objects looking like `{"partition": <parition_id:int>, "offset": <value:int>, "metadata": <metadata:string>}`