### PR TITLE
Simplify quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ herby effectively using the network bandwidth.
 ## Locality
 Kafka-Pixy is intended to run on the same host as the applications using it.
 Remember that it provides only message based API - no batching, therefore using
-it over network is suboptimal. To encourage local usage Kafka-Pixy binds to
-the Unix Domain Socket only by default. User has an option to enable a TCP
-listener but that is mostly for debugging purposes.
+it over network is suboptimal. To make local usage even more efficient
+Kafka-Pixy provides an option to serve its API via a Unix Domain Socket
+alongside a TCP socket (**0.0.0.0:19092** by default).
 
 ## HTTP API
 
@@ -210,8 +210,8 @@ that Kafka-Pixy accepts are listed below.
 ----------------|-------------------------------------------------------------------
  kafkaPeers     | Comma separated list of Kafka brokers. Note that these are just seed brokers. The rest brokers are discovered automatically. (Default **localhost:9092**)
  zookeeperPeers | Comma separated list of ZooKeeper nodes followed by optional chroot. (Default **localhost:2181**)
- unixAddr       | Unix Domain Socket that the primary HTTP API should listen on. (Default **/var/run/kafka-pixy.sock**)
- tcpAddr        | TCP interface where the secondary HTTP API should listen. If not specified then Kafka-Pixy won't listen on a TCP socket.
+ tcpAddr        | TCP interface where the HTTP API should listen. (Default **0.0.0.0:19092**)
+ unixAddr       | Unix Domain Socket that the HTTP API should listen on. If not specified then the service will not listen on a Unix Domain Socket. 
  pidFile        | Name of a pid file to create. If not specified then a pid file is not created.
 
 You can run `kafka-pixy -help` to make it list all available command line

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ that Kafka-Pixy accepts are listed below.
  zookeeperPeers | Comma separated list of ZooKeeper nodes followed by optional chroot. (Default **localhost:2181**)
  unixAddr       | Unix Domain Socket that the primary HTTP API should listen on. (Default **/var/run/kafka-pixy.sock**)
  tcpAddr        | TCP interface where the secondary HTTP API should listen. If not specified then Kafka-Pixy won't listen on a TCP socket.
- pidFile        | Name of the pid file to create. (Default **/var/run/kafka-pixy.pid**)
+ pidFile        | Name of a pid file to create. If not specified then a pid file is not created.
 
 You can run `kafka-pixy -help` to make it list all available command line
 parameters.

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ const (
 	defaultKafkaPeers     = "localhost:9092"
 	defaultZookeeperPeers = "localhost:2181"
 	defaultUnixAddr       = "/var/run/kafka-pixy.sock"
-	defaultPIDFile        = "/var/run/kafka-pixy.pid"
 	defaultLoggingCfg     = `[{"name": "console", "severity": "info"}]`
 )
 
@@ -39,7 +38,7 @@ func init() {
 		"TCP address that the HTTP API should listen on")
 	flag.StringVar(&kafkaPeers, "kafkaPeers", defaultKafkaPeers, "Comma separated list of brokers")
 	flag.StringVar(&zookeeperPeers, "zookeeperPeers", defaultZookeeperPeers, "Comma separated list of ZooKeeper nodes followed by optional chroot")
-	flag.StringVar(&pidFile, "pidFile", defaultPIDFile, "Path to the PID file")
+	flag.StringVar(&pidFile, "pidFile", "", "Path to the PID file")
 	flag.StringVar(&loggingJSONCfg, "logging", defaultLoggingCfg, "Logging configuration")
 	flag.Parse()
 
@@ -63,9 +62,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := writePID(pidFile); err != nil {
-		log.Errorf("Failed to write PID file: err=(%s)", err)
-		os.Exit(1)
+	if pidFile != "" {
+		if err := writePID(pidFile); err != nil {
+			log.Errorf("Failed to write PID file: err=(%s)", err)
+			os.Exit(1)
+		}
 	}
 
 	// Clean up the unix domain socket file in case we failed to clean up on

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 const (
 	defaultKafkaPeers     = "localhost:9092"
 	defaultZookeeperPeers = "localhost:2181"
-	defaultUnixAddr       = "/var/run/kafka-pixy.sock"
+	defaultTCPAddr        = "0.0.0.0:19092"
 	defaultLoggingCfg     = `[{"name": "console", "severity": "info"}]`
 )
 
@@ -32,10 +32,8 @@ func init() {
 	config = pixy.NewConfig()
 	var kafkaPeers, zookeeperPeers string
 
-	flag.StringVar(&config.UnixAddr, "unixAddr", defaultUnixAddr,
-		"Unix domain socket address that the HTTP API should listen on")
-	flag.StringVar(&config.TCPAddr, "tcpAddr", "",
-		"TCP address that the HTTP API should listen on")
+	flag.StringVar(&config.TCPAddr, "tcpAddr", defaultTCPAddr, "TCP address that the HTTP API should listen on")
+	flag.StringVar(&config.UnixAddr, "unixAddr", "", "Unix domain socket address that the HTTP API should listen on")
 	flag.StringVar(&kafkaPeers, "kafkaPeers", defaultKafkaPeers, "Comma separated list of brokers")
 	flag.StringVar(&zookeeperPeers, "zookeeperPeers", defaultZookeeperPeers, "Comma separated list of ZooKeeper nodes followed by optional chroot")
 	flag.StringVar(&pidFile, "pidFile", "", "Path to the PID file")
@@ -71,9 +69,11 @@ func main() {
 
 	// Clean up the unix domain socket file in case we failed to clean up on
 	// shutdown the last time. Otherwise the service won't be able to listen
-	// on this address and the service will terminated immediately.
-	if err := os.Remove(config.UnixAddr); err != nil && !os.IsNotExist(err) {
-		log.Errorf("Cannot remove %s: err=(%s)", config.UnixAddr, err)
+	// on this address and as a result will fail to start up.
+	if config.UnixAddr != "" {
+		if err := os.Remove(config.UnixAddr); err != nil && !os.IsNotExist(err) {
+			log.Errorf("Cannot remove %s: err=(%s)", config.UnixAddr, err)
+		}
 	}
 
 	log.Infof("Starting with config: %+v", config)

--- a/pixy/httpapi.go
+++ b/pixy/httpapi.go
@@ -76,9 +76,6 @@ func NewHTTPAPIServer(network, addr string, producer *GracefulProducer, consumer
 		as.handleProduce).Methods("POST")
 	router.HandleFunc(fmt.Sprintf("/topics/{%s}/messages", ParamTopic),
 		as.handleConsume).Methods("GET")
-	// TODO deprecated endpoint, use `/topics/{topic}/messages` instead.
-	router.HandleFunc(fmt.Sprintf("/topics/{%s}", ParamTopic),
-		as.handleProduce).Methods("POST")
 	router.HandleFunc(fmt.Sprintf("/topics/{%s}/offsets", ParamTopic),
 		as.handleGetOffsets).Methods("GET")
 	router.HandleFunc(fmt.Sprintf("/topics/{%s}/offsets", ParamTopic),

--- a/pixy/service_test.go
+++ b/pixy/service_test.go
@@ -302,7 +302,7 @@ func (s *ServiceSuite) TestSyncProduceInvalidTopic(c *C) {
 	defer svc.Stop()
 
 	// When
-	r, err := s.unixClient.Post("http://_/topics/no-such-topic?sync=true",
+	r, err := s.unixClient.Post("http://_/topics/no-such-topic/messages?sync=true",
 		"text/plain", strings.NewReader("Foo"))
 
 	// Then

--- a/tools/testconsumer/testconsumer.go
+++ b/tools/testconsumer/testconsumer.go
@@ -29,7 +29,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&pixyAddr, "addr", "/var/run/kafka-pixy.sock", "either unix domain socker or TCP address")
+	flag.StringVar(&pixyAddr, "addr", "localhost:19092", "either unix domain socker or TCP address")
 	flag.StringVar(&group, "group", "test", "the name of the consumer group")
 	flag.StringVar(&topic, "topic", "test", "the name of the topic")
 	flag.IntVar(&threads, "threads", 1, "number of concurrent producer threads")

--- a/tools/testproducer/testproducer.go
+++ b/tools/testproducer/testproducer.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&pixyAddr, "addr", "/var/run/kafka-pixy.sock", "either unix domain socker or TCP address")
+	flag.StringVar(&pixyAddr, "addr", "localhost:19092", "either unix domain socker or TCP address")
 	flag.StringVar(&topic, "topic", "test", "the name of the topic")
 	flag.BoolVar(&isSync, "sync", false, "should production be synchronous")
 	flag.IntVar(&threads, "threads", 1, "number of concurrent producer threads")


### PR DESCRIPTION
Having the proxy listen on a Unix socket makes it a bit more involved to give it a try, for a directory accessible for the current user should be created outside of his home folder and `--unixAddr` parameter should be specified. On the other hand to give the proxy a try a user would need to explicitly specify a tcp port for the proxy to listen on. That said it makes more sense to enable a tcp port **19092** by default, and allow users to optionally specify a unix domain socket. Following the same logic the pid file was also made optional.