### PR TITLE
fix issue w/client ID validation + set ID for producer connection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -103,6 +104,8 @@ func newClientID() string {
 		}
 	}
 	timestamp := time.Now().UTC().Format(time.RFC3339)
+	// sarama validation regexp for the client ID doesn't allow ':' characters
+	timestamp = strings.Replace(timestamp, ":", ".", -1)
 	return fmt.Sprintf("pixy_%s_%d_%s", hostname, os.Getpid(), timestamp)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func newClientID() string {
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	// sarama validation regexp for the client ID doesn't allow ':' characters
 	timestamp = strings.Replace(timestamp, ":", ".", -1)
-	return fmt.Sprintf("pixy_%s_%d_%s", hostname, os.Getpid(), timestamp)
+	return fmt.Sprintf("pixy_%s_%s_%d", hostname, timestamp, os.Getpid())
 }
 
 func getIP() (net.IP, error) {

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -44,6 +44,7 @@ type produceResult struct {
 func Spawn(cfg *config.T) (*T, error) {
 	saramaCfg := sarama.NewConfig()
 	saramaCfg.ChannelBufferSize = cfg.Producer.ChannelBufferSize
+	saramaCfg.ClientID = fmt.Sprintf("%s_producer", cfg.ClientID)
 	saramaCfg.Producer.RequiredAcks = sarama.WaitForAll
 	saramaCfg.Producer.Return.Successes = true
 	saramaCfg.Producer.Return.Errors = true


### PR DESCRIPTION
Sarama validates the `ClientID` config flag with a regexp that disallows the `:` characters included in the timestamp format used in kafka-pixy. This change converts those to periods, and as a bonus squelches a warning generated by the producer client logic caused by a lack of a unique, non-null `ClientID` value there.