### PR TITLE
Add 2 http routes to retrieve list of topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ _testmain.go
 *.test
 *.prof
 .idea/
+*.iml
+
+kafka-pixy
+.vagrant/

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -309,3 +309,7 @@ func (p *T) GetAllTopicConsumers(topic string) (map[string]map[string][]int32, e
 	}
 	return p.admin.GetAllTopicConsumers(topic)
 }
+
+func (p *T) GetTopicsMetadata(withPartitions, withConfig bool) ([]admin.TopicMetadata, error) {
+	return p.admin.GetTopicsMetadata(withPartitions, withConfig)
+}


### PR DESCRIPTION
Two HTTP GET routes to retrieve list of topics are added: **/topics**, and **/cluster/{cluster_id}/topics**
It returns a list of topics, for instance ["__consumer_offsets", "test.64", "test.1", "test.4"]
There are 2 additional parameters: **withPartitions**, and **withConfig**. 
If these parameters are provided to the route, for instance **/topics?withPartitions&withConfig**, it returns the partitions information and the configuration for every topic, for instance
```
{  "__consumer_offsets": {
    "topic_config": {
      "version": 1,
      "config": {
        "cleanup.policy": "compact", 
        "compression.type": "producer", 
        "segment.bytes": "104857600"
      }
    },
    "partitions": [
      {
        "partition": 0,
        "leader": 9092,
        "replicas": [
          9091,
          9092,
          9095
        ],
        "isr": [
          9091,
          9092,
          9095
        ]
      }, ... ], ...
}
```