### PR TITLE
Allow infinite retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Version 0.14.0 (TBD)
 
 Implemented:
+* Added HTTP API endpoints to list topics optionally with partitions and
+  configuration.
 * Ack timeout can now be greater then subscription timeout. So in absence of
   incoming consume requests for a topic, rebalancing may be delayed until
   ack timeout expires for all offered messages. If a new request comes while

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ group inactivity on all Kafka-Pixy working with the Kafka cluster.
 
 ```
 GET /topics/<topic>/consumers
-GET /clusters/<topic>/topics/<topic>/consumers
+GET /clusters/<cluster>/topics/<topic>/consumers
 ```
 
 Returns a list of consumers that are subscribed to a topic.
@@ -343,6 +343,35 @@ yields:
   }
 }
 ```
+
+### List Topics
+
+```
+GET /topics
+GET /clusters/<cluster>/topics
+```
+
+Returns a list of topics optionally with detailed configuration and partitions.
+
+ Parameter      | Opt | Description
+----------------|-----|------------------------------------------------
+ cluster        | yes | The name of a cluster to operate on. By default the cluster mentioned first in the `proxies` section of the config file is used.
+ withPartitions | yes | Whether a list of partitions should be returned for every topic.
+ withConfig     | yes | Whether configuration should be returned for every topic.
+
+### Get Topic Config
+
+```
+GET /topics/<topic>
+GET /clusters/<cluster>/topics/<topic>
+```
+
+Returns topic configuration optionally with a list of partitions.
+
+ Parameter      | Opt | Description
+----------------|-----|------------------------------------------------
+ cluster        | yes | The name of a cluster to operate on. By default the cluster mentioned first in the `proxies` section of the config file is used.
+ withPartitions | yes | Whether a list of partitions should be returned.
 
 ## Configuration
 

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -179,7 +179,7 @@ func (a *T) getGroupOffsets(group, topic string) ([]PartitionOffset, error) {
 	// Fetch the last committed offsets for all partitions of the group/topic.
 	coordinator, err := kafkaClt.Coordinator(group)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get coordinator")
+		return nil, errors.Wrap(err, "failed to get coordinator")
 	}
 	req := sarama.OffsetFetchRequest{ConsumerGroup: group, Version: ProtocolVer1}
 	for _, p := range partitions {
@@ -187,7 +187,7 @@ func (a *T) getGroupOffsets(group, topic string) ([]PartitionOffset, error) {
 	}
 	res, err := coordinator.FetchOffset(&req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch offsets")
+		return nil, errors.Wrap(err, "failed to fetch offsets")
 	}
 	for i, p := range partitions {
 		block := res.GetBlock(topic, p)
@@ -218,7 +218,7 @@ func (a *T) setGroupOffsets(group, topic string, offsets []PartitionOffset) erro
 	}
 	coordinator, err := kafkaClt.Coordinator(group)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get coordinator")
+		return errors.Wrap(err, "failed to get coordinator")
 	}
 
 	req := sarama.OffsetCommitRequest{
@@ -231,7 +231,7 @@ func (a *T) setGroupOffsets(group, topic string, offsets []PartitionOffset) erro
 	}
 	res, err := coordinator.CommitOffset(&req)
 	if err != nil {
-		return errors.Wrapf(err, "failed to commit offsets")
+		return errors.Wrap(err, "failed to commit offsets")
 	}
 	for p, err := range res.Errors[topic] {
 		if err != sarama.ErrNoError {
@@ -255,7 +255,7 @@ func (a *T) GetTopicConsumers(group, topic string) (map[string][]int32, error) {
 		if err == zk.ErrNoNode {
 			return nil, ErrInvalidParam(errors.New("either group or topic is incorrect"))
 		}
-		return nil, errors.Wrapf(err, "failed to fetch partition owners data")
+		return nil, errors.Wrap(err, "failed to fetch partition owners data")
 	}
 
 	consumers := make(map[string][]int32)
@@ -267,7 +267,7 @@ func (a *T) GetTopicConsumers(group, topic string) (map[string][]int32, error) {
 		partitionPath := fmt.Sprintf("%s/%s", consumedPartitionsPath, partitionNode)
 		partitionNodeData, _, err := zkConn.Get(partitionPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to fetch partition owner")
+			return nil, errors.Wrap(err, "failed to fetch partition owner")
 		}
 		clientID := string(partitionNodeData)
 		consumers[clientID] = append(consumers[clientID], int32(partition))
@@ -291,7 +291,7 @@ func (a *T) GetAllTopicConsumers(topic string) (map[string]map[string][]int32, e
 	groupsPath := fmt.Sprintf("%s/consumers", a.cfg.ZooKeeper.Chroot)
 	groups, _, err := kzConn.Children(groupsPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch consumer groups")
+		return nil, errors.Wrap(err, "failed to fetch consumer groups")
 	}
 
 	consumers := make(map[string]map[string][]int32)
@@ -424,7 +424,7 @@ func (a *T) GetTopicMetadata(topic string, withPartitions, withConfig bool) (Top
 		}
 		topicConfig := TopicConfig{}
 		if err = json.Unmarshal(cfg, &topicConfig); err != nil {
-			return TopicMetadata{}, errors.Wrapf(err, "bad config")
+			return TopicMetadata{}, errors.Wrap(err, "bad config")
 		}
 		tm.Config = &topicConfig
 	}

--- a/consumer/offsettrk/offsettrk.go
+++ b/consumer/offsettrk/offsettrk.go
@@ -127,8 +127,8 @@ func (ot *T) OnAcked(offset int64) (offsetmgr.Offset, int) {
 	offerRemoved := ot.removeOffer(offset)
 	ackedRangesUpdated := ot.updateAckedRanges(offset)
 	if !offerRemoved || !ackedRangesUpdated {
-		ot.actDesc.Log().Errorf("Bad ack: offerMissing=%t, duplicateAck=%t",
-			!offerRemoved, !ackedRangesUpdated)
+		ot.actDesc.Log().Errorf("Bad ack: offset=%d, offerMissing=%t, duplicateAck=%t",
+			offset, !offerRemoved, !ackedRangesUpdated)
 	}
 	if ackedRangesUpdated {
 		ot.offset.Meta = encodeAckedRanges(ot.offset.Val, ot.ackedRanges)

--- a/consumer/partitioncsm/partitioncsm.go
+++ b/consumer/partitioncsm/partitioncsm.go
@@ -247,7 +247,7 @@ func (pc *T) runFetchLoop() bool {
 // returned or there are no more messages to be retried.
 func (pc *T) nextRetry() (consumer.Message, bool) {
 	msg, retryNo, ok := pc.offsetTrk.NextRetry()
-	for ok && retryNo > pc.cfg.Consumer.MaxRetries {
+	for ok && pc.cfg.Consumer.MaxRetries >= 0 && retryNo > pc.cfg.Consumer.MaxRetries {
 		pc.actDesc.Log().Errorf("Too many retries: retryNo=%d, offset=%d, key=%s, msg=%s",
 			retryNo, msg.Offset, string(msg.Key), base64.StdEncoding.EncodeToString(msg.Value))
 		pc.submittedOffset, _ = pc.offsetTrk.OnAcked(msg.Offset)

--- a/default.yaml
+++ b/default.yaml
@@ -114,11 +114,14 @@ proxies:
       # the pending messages are acknowledged.
       max_pending_messages: 300
 
-      # The maximum number of times a message can be offered to a consumer.
-      # If a message had been offered that many times and no acknowledgment has
-      # been received, then it is forcefully acknowledged and will never be
-      # offered again. Such messages are lost from the Kafka-Pixy point of view.
-      max_retries: 3
+      # The maximum number of retries Kafka-Pixy will make to offer an
+      # unack message. Messages that exceeded the number of retries are
+      # discarded by Kafka-Pixy and acknowledged in Kafka. Zero retries
+      # means that messages will be offered just once.
+      #
+      # If you want Kafka-Pixy to retry indefinitely, then set this
+      # parameter to -1.
+      max_retries: -1
 
       # How frequently to commit offsets to Kafka.
       offsets_commit_interval: 500ms

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -310,6 +310,23 @@ func (p *T) GetAllTopicConsumers(topic string) (map[string]map[string][]int32, e
 	return p.admin.GetAllTopicConsumers(topic)
 }
 
-func (p *T) GetTopicsMetadata(withPartitions, withConfig bool) ([]admin.TopicMetadata, error) {
-	return p.admin.GetTopicsMetadata(withPartitions, withConfig)
+// ListTopics returns a list of all topics existing in the Kafka cluster.
+func (p *T) ListTopics(withPartitions, withConfig bool) ([]admin.TopicMetadata, error) {
+	p.adminMu.RLock()
+	defer p.adminMu.RUnlock()
+	if p.admin == nil {
+		return nil, ErrUnavailable
+	}
+	return p.admin.ListTopics(withPartitions, withConfig)
+}
+
+// GetTopicMetadata returns a topic metadata. An optional partition metadata
+// can be requested and/or detailed topic configuration can be requested.
+func (p *T) GetTopicMetadata(topic string, withPartitions, withConfig bool) (admin.TopicMetadata, error) {
+	p.adminMu.RLock()
+	defer p.adminMu.RUnlock()
+	if p.admin == nil {
+		return admin.TopicMetadata{}, ErrUnavailable
+	}
+	return p.admin.GetTopicMetadata(topic, withPartitions, withConfig)
 }

--- a/service/service_grpc_test.go
+++ b/service/service_grpc_test.go
@@ -55,11 +55,11 @@ func (s *ServiceGRPCSuite) TearDownTest(c *C) {
 func (s *ServiceGRPCSuite) TestProduceWithKey(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	offsetsBefore := s.kh.GetNewestOffsets("test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -89,11 +89,11 @@ func (s *ServiceGRPCSuite) TestProduceWithKey(c *C) {
 func (s *ServiceGRPCSuite) TestProduceKeyUndefined(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	offsetsBefore := s.kh.GetNewestOffsets("test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -124,11 +124,11 @@ func (s *ServiceGRPCSuite) TestProduceKeyUndefined(c *C) {
 func (s *ServiceGRPCSuite) TestProduceDefaultKey(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	offsetsBefore := s.kh.GetNewestOffsets("test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -159,11 +159,11 @@ func (s *ServiceGRPCSuite) TestProduceSync(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
 	defer svc.Stop()
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	offsetsBefore := s.kh.GetNewestOffsets("test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -183,9 +183,9 @@ func (s *ServiceGRPCSuite) TestProduceInvalidProxy(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
 	defer svc.Stop()
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -207,14 +207,14 @@ func (s *ServiceGRPCSuite) TestProduceInvalidProxy(c *C) {
 func (s *ServiceGRPCSuite) TestConsumeAutoAck(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.4")
 	produced := s.kh.PutMessages("auto-ack", "test.4", map[string]int{"A": 17, "B": 19, "C": 23, "D": 29})
 	consumed := make(map[string][]*pb.ConsRs)
 	offsetsBefore := s.kh.GetCommittedOffsets("foo", "test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -248,13 +248,13 @@ func (s *ServiceGRPCSuite) TestConsumeNoAck(c *C) {
 	s.proxyCfg.Consumer.SubscriptionTimeout = 500 * time.Millisecond
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.1")
 	s.kh.PutMessages("no-ack", "test.1", map[string]int{"A": 1})
 	offsetsBefore := s.kh.GetCommittedOffsets("foo", "test.1")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -276,7 +276,7 @@ func (s *ServiceGRPCSuite) TestConsumeNoAck(c *C) {
 func (s *ServiceGRPCSuite) TestGetOffsets(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.4")
 	s.kh.PutMessages("auto-ack", "test.4", map[string]int{"A": 1})
@@ -316,14 +316,14 @@ func (s *ServiceGRPCSuite) TestGetOffsets(c *C) {
 func (s *ServiceGRPCSuite) TestConsumeExplicitAck(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.4")
 	produced := s.kh.PutMessages("explicit-ack", "test.4", map[string]int{"A": 17, "B": 19, "C": 23, "D": 29})
 	consumed := make(map[string][]*pb.ConsRs)
 	offsetsBefore := s.kh.GetCommittedOffsets("foo", "test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When:
@@ -377,11 +377,11 @@ func (s *ServiceGRPCSuite) TestConsumeExplicitProxy(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
 	defer svc.Stop()
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	prodReq := pb.ProdRq{
@@ -412,11 +412,11 @@ func (s *ServiceGRPCSuite) TestConsumeKeyUndefined(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
 	defer svc.Stop()
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
 	s.kh.ResetOffsets("foo", "test.4")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	prodReq := pb.ProdRq{
@@ -446,9 +446,9 @@ func (s *ServiceGRPCSuite) TestConsumeInvalidProxy(c *C) {
 	svc, err := Spawn(s.cfg)
 	c.Assert(err, IsNil)
 	defer svc.Stop()
-	s.waitSvcUp(c, 1*time.Second)
+	s.waitSvcUp(c, 5*time.Second)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// When
@@ -474,5 +474,6 @@ func (s *ServiceGRPCSuite) waitSvcUp(c *C, timeout time.Duration) {
 			c.Errorf("Service is not up")
 			return
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/service/service_http_test.go
+++ b/service/service_http_test.go
@@ -920,7 +920,7 @@ func (s *ServiceHTTPSuite) TestGetTopicsWithConfig(c *C) {
 			c.Error(fmt.Sprintf("Can't obtain config for %s error %v", topic, err))
 		}
 
-		cfg := metadata["topic_config"].(map[string]interface{})
+		cfg := metadata["config"].(map[string]interface{})
 		version := int(cfg["version"].(float64))
 		c.Assert(version, Equals, 1)
 
@@ -959,7 +959,7 @@ func (s *ServiceHTTPSuite) TestGetTopicsWithPartitionsAndWithConfig(c *C) {
 
 		metadata := raw_metadata.(map[string]interface{})
 		c.Assert(metadata["partitions"], NotNil)
-		c.Assert(metadata["topic_config"], NotNil)
+		c.Assert(metadata["config"], NotNil)
 	}
 }
 


### PR DESCRIPTION
If Consumer.MaxRetries is set to -1 then Kafka-Pixy will retry indefinitely.

Besides `/topic/<topic>` HTTP API endpoints were added that that return information similar to `/topic` but for a specific topic.