### PR TITLE
 Restore subscription if inconsistent

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -360,15 +360,16 @@ func (a *T) ListTopics(withPartitions, withConfig bool) ([]TopicMetadata, error)
 		return nil, errors.Wrap(err, "failed to get topics")
 	}
 
-	topicsMetadata := make([]TopicMetadata, len(topics))
+	topicMetadatas := make([]TopicMetadata, len(topics))
 	for i, topic := range topics {
 		tm, err := a.GetTopicMetadata(topic, withPartitions, withConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get %s topic metadata", topic)
 		}
-		topicsMetadata[i] = tm
+		topicMetadatas[i] = tm
 	}
-	return topicsMetadata, nil
+	sort.Slice(topicMetadatas, func(i, j int) bool { return topicMetadatas[i].Topic < topicMetadatas[j].Topic })
+	return topicMetadatas, nil
 }
 
 // GetTopicMetadata returns a topic metadata. An optional partition metadata

--- a/consumer/subscriber/subscriber.go
+++ b/consumer/subscriber/subscriber.go
@@ -2,6 +2,7 @@ package subscriber
 
 import (
 	"context"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -228,6 +229,15 @@ func (ss *T) run() {
 			shouldFetchSubscriptions = false
 			ss.actDesc.Log().Infof("Fetched subscriptions: %s", prettyfmt.Val(subscriptions))
 			nilOrSubscriptionsCh = ss.subscriptionsCh
+
+			// If fetched topics are not the same as the current subscription
+			// then initiate topic submission.
+			fetchedTopics := subscriptions[ss.cfg.ClientID]
+			if reflect.DeepEqual(topics, fetchedTopics) {
+				continue
+			}
+			ss.actDesc.Log().Errorf("Outdated subscription: want=%v, got=%v", topics, fetchedTopics)
+			shouldSubmitTopics = true
 		}
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mailgun/kafka-pixy/offsetmgr"
 	"github.com/mailgun/kafka-pixy/producer"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -218,7 +219,11 @@ func (p *T) Consume(group, topic string, ack Ack) (consumer.Message, error) {
 				select {
 				case eventsCh <- consumer.Ack(ack.offset):
 				case <-time.After(p.cfg.Consumer.LongPollingTimeout):
-					p.actDesc.Log().Errorf("ack timeout: partition=%d, offset=%d", ack.partition, ack.offset)
+					p.actDesc.Log().WithFields(log.Fields{
+						"kafka.group":     group,
+						"kafka.topic":     topic,
+						"kafka.partition": ack.partition,
+					}).Errorf("ack timeout: offset=%d", ack.offset)
 				}
 			}()
 		}


### PR DESCRIPTION
If Kafka-Pixy fetches from ZooKeeper its own subscription (topic list) that is different from what it is supposed to be, then it re-submitts subscription to restore.