### PR TITLE
Let command line args override provided config

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,17 +89,17 @@ func main() {
 
 func makeConfig() (*config.App, error) {
 	var cfg *config.App
-	// If a YAML configuration file is provided, then load it and ignore all
-	// parameters provided on the command line.
+	// If a YAML configuration file is provided, then load it and let
+	// parameters provided on the command line override values on it.
 	if cmdConfig != "" {
 		var err error
 		if cfg, err = config.FromYAMLFile(cmdConfig); err != nil {
 			return nil, err
 		}
-		return cfg, nil
+	} else {
+		cfg = config.DefaultApp(defaultCluster)
 	}
 
-	cfg = config.DefaultApp(defaultCluster)
 	if cmdGRPCAddr != "" {
 		cfg.GRPCAddr = cmdGRPCAddr
 	}


### PR DESCRIPTION
According to the documentation in README.md:

    "If some option is both specified in the configuration file and provided as a command line argument, then the command line argument wins."

but the func makeConfig(), in main.go says:

	// If a YAML configuration file is provided, then load it and let
	// parameters provided on the command line override values on it.

This pull requests allows the command line parameters override the provided config file.

In addition, this behavior is consistent to use it in a `Dockerfile`, the user can provide a config file for specific parameters and using command line commands to override URLs and ports with environment variables.