### PR TITLE
Flush pending offsets on offset manager stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 #### Version 0.15.0 (TBD)
 
 Implemented:
-* Added support for Kafka v0.11.0.0 - v1.0.0
+* [#135](https://github.com/mailgun/kafka-pixy/issues/135) Added support for
+  Kafka v0.11.0.0 - v1.0.0
 * Consumer.RebalanceTimeout was removed, so rebalancing is triggered as soon
   as membership status of a consumer group or subscription of a consumer group
   member changes.
+* [#138](https://github.com/mailgun/kafka-pixy/issues/138) Pending offsets are
+  committed to Kafka faster on rebalancing. That could take upto
+  `consumer.offsets_commit_interval` before, but now it happens as soon as
+  possible.
 
 Fixed:
 * [#120](https://github.com/mailgun/kafka-pixy/issues/120) Consumption from a

--- a/config/config.go
+++ b/config/config.go
@@ -138,10 +138,6 @@ type Proxy struct {
 		// How frequently to commit offsets to Kafka.
 		OffsetsCommitInterval time.Duration `yaml:"offsets_commit_interval"`
 
-		// How long to wait for an offset to be committed by Kafka before
-		// retrying.
-		OffsetsCommitTimeout time.Duration `yaml:"offsets_commit_timeout"`
-
 		// Kafka-Pixy should wait this long after it gets notification that a
 		// consumer joined/left a consumer group it is a member of before
 		// rebalancing.
@@ -379,8 +375,6 @@ func (p *Proxy) validate() error {
 		return errors.New("consumer.max_retries must be >= -1")
 	case p.Consumer.OffsetsCommitInterval <= 0:
 		return errors.New("consumer.offsets_commit_interval must be > 0")
-	case p.Consumer.OffsetsCommitTimeout <= 0:
-		return errors.New("consumer.offsets_commit_timeout must be > 0")
 	case p.Consumer.SubscriptionTimeout <= 0:
 		return errors.New("consumer.subscription_timeout must be > 0")
 	case p.Consumer.RetryBackoff <= 0:
@@ -430,7 +424,6 @@ func defaultProxyWithClientID(clientID string) *Proxy {
 	c.Consumer.MaxPendingMessages = 300
 	c.Consumer.MaxRetries = -1
 	c.Consumer.OffsetsCommitInterval = 500 * time.Millisecond
-	c.Consumer.OffsetsCommitTimeout = 1500 * time.Millisecond
 	c.Consumer.SubscriptionTimeout = 15 * time.Second
 	c.Consumer.RetryBackoff = 500 * time.Millisecond
 	return c

--- a/offsetmgr/offsetmgr.go
+++ b/offsetmgr/offsetmgr.go
@@ -161,13 +161,15 @@ func (f *factory) ResolveBroker(worker mapper.Worker) (*sarama.Broker, error) {
 // implements `mapper.Resolver`.
 func (f *factory) SpawnExecutor(brokerConn *sarama.Broker) mapper.Executor {
 	be := &brokerExecutor{
-		aggrActDesc:      f.actDesc.NewChild("broker", brokerConn.ID(), "aggr"),
-		execActDesc:      f.actDesc.NewChild("broker", brokerConn.ID(), "exec"),
-		cfg:              f.cfg,
-		conn:             brokerConn,
-		requestsCh:       make(chan submitRq),
-		requestBatchesCh: make(chan map[string]map[instanceID]submitRq),
-		execStopCh:       make(chan none.T),
+		aggrActDesc:       f.actDesc.NewChild("broker", brokerConn.ID(), "aggr"),
+		execActDesc:       f.actDesc.NewChild("broker", brokerConn.ID(), "exec"),
+		cfg:               f.cfg,
+		conn:              brokerConn,
+		requestsCh:        make(chan submitRq),
+		requestBatchesCh:  make(chan map[string]map[instanceID]submitRq),
+		flushAggregatorCh: make(chan none.T, 1),
+		flushExecutorCh:   make(chan none.T, 1),
+		execStopCh:        make(chan none.T),
 	}
 	actor.Spawn(be.aggrActDesc, &be.wg, be.runAggregator)
 	actor.Spawn(be.execActDesc, &be.wg, be.runExecutor)
@@ -263,8 +265,7 @@ func (om *offsetMgr) run() {
 
 			initialOffset, err := om.fetchInitialOffset(be.conn)
 			if err != nil {
-				om.actDesc.Log().WithError(err).Error("Failed to fetch initial offset")
-				om.triggerReassign(err)
+				om.triggerReassign(err, "Failed to fetch initial offset")
 				continue
 			}
 			om.committedOffsetsCh <- initialOffset
@@ -295,11 +296,12 @@ handleRequests:
 	}
 	var handedOffRq submitRq
 	var handOffTime time.Time
+	var be *brokerExecutor
 	for {
 		select {
 		case bw := <-om.assignmentCh:
 			om.actDesc.Log().Infof("Assigned executor: %s", bw)
-			be := bw.(*brokerExecutor)
+			be = bw.(*brokerExecutor)
 			om.brokerRequestsCh = be.requestsCh
 
 			if receivedRq.offset != committedOffset {
@@ -312,6 +314,10 @@ handleRequests:
 				}
 				// Keep running until the last submitter offset is committed.
 				stopped = true
+				// Signal broker executor to flush offsets to Kafka.
+				if be != nil {
+					be.flushAggregatorCh <- none.V
+				}
 				nilOrRequestsCh = nil
 				continue
 			}
@@ -329,8 +335,7 @@ handleRequests:
 			}
 		case rs := <-responseCh:
 			if err := om.getCommitError(rs.kafkaRs); err != nil {
-				om.actDesc.Log().WithError(err).Error("Request failed")
-				om.triggerReassign(err)
+				om.triggerReassign(err, "Request failed")
 				continue
 			}
 			committedOffset = rs.rq.offset
@@ -345,8 +350,7 @@ handleRequests:
 				if handedOffRq.offset == committedOffset {
 					continue
 				}
-				om.actDesc.Log().Errorf("Request timeout %v", sinceHandOff)
-				om.triggerReassign(errRequestTimeout)
+				om.triggerReassign(errRequestTimeout, "Request timeout %v", sinceHandOff)
 				continue
 			}
 			timeoutLeft := om.f.cfg.Consumer.OffsetsCommitTimeout - sinceHandOff
@@ -366,7 +370,8 @@ func (om *offsetMgr) stopRetryTimer() {
 	om.nilOrRetryTimerCh = nil
 }
 
-func (om *offsetMgr) triggerReassign(err error) {
+func (om *offsetMgr) triggerReassign(err error, format string, args ...interface{}) {
+	om.actDesc.Log().WithError(err).Errorf(format, args...)
 	om.stopRetryTimer()
 	if om.testErrorsCh != nil {
 		om.testErrorsCh <- err
@@ -431,14 +436,16 @@ type submitRs struct {
 //
 // implements `mapper.Executor`.
 type brokerExecutor struct {
-	aggrActDesc      *actor.Descriptor
-	execActDesc      *actor.Descriptor
-	cfg              *config.Proxy
-	conn             *sarama.Broker
-	requestsCh       chan submitRq
-	requestBatchesCh chan map[string]map[instanceID]submitRq
-	execStopCh       chan none.T
-	wg               sync.WaitGroup
+	aggrActDesc       *actor.Descriptor
+	execActDesc       *actor.Descriptor
+	cfg               *config.Proxy
+	conn              *sarama.Broker
+	requestsCh        chan submitRq
+	requestBatchesCh  chan map[string]map[instanceID]submitRq
+	flushAggregatorCh chan none.T
+	flushExecutorCh   chan none.T
+	execStopCh        chan none.T
+	wg                sync.WaitGroup
 }
 
 // implements `mapper.Executor`.
@@ -470,6 +477,10 @@ func (be *brokerExecutor) runAggregator() {
 			}
 			groupRequests[rq.id] = rq
 			nilOrOffsetBatchesCh = be.requestBatchesCh
+
+		case <-be.flushAggregatorCh:
+			be.flushExecutorCh <- none.V
+
 		case nilOrOffsetBatchesCh <- requestBatch:
 			nilOrOffsetBatchesCh = nil
 			requestBatch = make(map[string]map[instanceID]submitRq)
@@ -510,6 +521,9 @@ offsetCommitLoop:
 					rq.resultCh <- submitRs{rq, kafkaRs}
 				}
 			}
+		case <-be.flushExecutorCh:
+			nilOrRequestBatchesCh = be.requestBatchesCh
+
 		case <-commitTicker.C:
 			// Skip several circles after a connection failure to allow a Kafka
 			// cluster some time to recuperate. Some requests will timeout

--- a/offsetmgr/offsetmgr_test.go
+++ b/offsetmgr/offsetmgr_test.go
@@ -393,7 +393,6 @@ func (s *OffsetMgrSuite) TestCommitNetworkError(c *C) {
 	cfg := testhelpers.NewTestProxyCfg("c1")
 	cfg.Consumer.RetryBackoff = 100 * time.Millisecond
 	cfg.Consumer.OffsetsCommitInterval = 50 * time.Millisecond
-	cfg.Consumer.OffsetsCommitTimeout = 150 * time.Millisecond
 	saramaCfg := sarama.NewConfig()
 	saramaCfg.Net.ReadTimeout = 50 * time.Millisecond
 	client, err := sarama.NewClient([]string{broker1.Addr()}, saramaCfg)


### PR DESCRIPTION
It used to wait up to [consumer. offsets_commit_interval](https://github.com/mailgun/kafka-pixy/blob/master/default.yaml#L127) before committing a pending offset to Kafka even when an offset manager instance for a group-topic-partition was stopped. With this change stopping an offset manager instance triggers immediate flush of pending offsets to Kafka.