### PR TITLE
add MaxMessageBytes kafka producer parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,9 @@ type Proxy struct {
 		// Size of all buffered channels created by the producer module.
 		ChannelBufferSize int `yaml:"channel_buffer_size"`
 
+		// Size of maximum message in bytes
+		MaxMessageBytes int `yaml:"max_message_bytes"`
+
 		// The type of compression to use on messages.
 		Compression Compression `yaml:"compression"`
 
@@ -240,6 +243,7 @@ func (p *Proxy) SaramaProducerCfg() *sarama.Config {
 	saramaCfg.ClientID = p.ClientID
 	saramaCfg.Version = p.Kafka.Version.v
 
+	saramaCfg.Producer.MaxMessageBytes = p.Producer.MaxMessageBytes
 	saramaCfg.Producer.Compression = sarama.CompressionCodec(p.Producer.Compression)
 	saramaCfg.Producer.Flush.Frequency = p.Producer.FlushFrequency
 	saramaCfg.Producer.Flush.Bytes = p.Producer.FlushBytes
@@ -408,6 +412,7 @@ func defaultProxyWithClientID(clientID string) *Proxy {
 	}
 
 	c.Producer.ChannelBufferSize = 4096
+	c.Producer.MaxMessageBytes = 1000000
 	c.Producer.Compression = Compression(sarama.CompressionSnappy)
 	c.Producer.FlushFrequency = 500 * time.Millisecond
 	c.Producer.FlushBytes = 1024 * 1024

--- a/default.yaml
+++ b/default.yaml
@@ -50,6 +50,10 @@ proxies:
 
       # Size of all buffered channels created by the producer module.
       channel_buffer_size: 4096
+      
+      # The maximum permitted size of a message (defaults to 1000000). Should be
+      # set equal to or smaller than the broker's `message.max.bytes`.
+      max_message_bytes: 1000000
 
       # The type of compression to use on messages. Allowed values are:
       # none, gzip, snappy, and lz4.


### PR DESCRIPTION
For pushing to kafka messages larger then 1000000 bytes, you need to set this parameter.
By default it sets to 1000000 bytes ( https://github.com/Shopify/sarama/blob/master/config.go#L293 )
