### PR TITLE
Avoid rejection of +json content types at produce

### DIFF
--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -52,6 +52,7 @@ const (
 
 var (
 	EmptyResponse = map[string]interface{}{}
+	JsonTest, JsonTestCompileErr = regexp.Compile("^application/(?:.*\\+)?json$")
 )
 
 type T struct {
@@ -230,9 +231,8 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 
 // readMsg reads message from the HTTP request based on the Content-Type header.
 func (s *T) readMsg(r *http.Request) (sarama.Encoder, error) {
-	jsonTest, _ := regexp.Compile("^application/(?:.*\\+)?json$")
 	contentType := r.Header.Get(hdrContentType)
-	if contentType == "text/plain" || jsonTest.MatchString(contentType) {
+	if contentType == "text/plain" || JsonTest.MatchString(contentType) {
 		if _, ok := r.Header[hdrContentLength]; !ok {
 			return nil, errors.Errorf("missing %s header", hdrContentLength)
 		}

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -229,8 +230,9 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 
 // readMsg reads message from the HTTP request based on the Content-Type header.
 func (s *T) readMsg(r *http.Request) (sarama.Encoder, error) {
+	jsonTest, _ := regexp.Compile("^application/(?:.*\\+)?json$")
 	contentType := r.Header.Get(hdrContentType)
-	if contentType == "text/plain" || contentType == "application/json" {
+	if contentType == "text/plain" || jsonTest.MatchString(contentType) {
 		if _, ok := r.Header[hdrContentLength]; !ok {
 			return nil, errors.Errorf("missing %s header", hdrContentLength)
 		}

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -52,7 +52,7 @@ const (
 
 var (
 	EmptyResponse = map[string]interface{}{}
-	JsonTest, JsonTestCompileErr = regexp.Compile("^application/(?:.*\\+)?json$")
+	jsonTest, jsonTestCompileErr = regexp.Compile("^application/(?:.*\\+)?json$")
 )
 
 type T struct {
@@ -63,6 +63,12 @@ type T struct {
 	proxySet   *proxy.Set
 	wg         sync.WaitGroup
 	errorCh    chan error
+}
+
+func init() {
+	if jsonTestCompileErr != nil {
+		panic(jsonTestCompileErr)
+	}
 }
 
 // New creates an HTTP server instance that will accept API requests at the
@@ -232,7 +238,7 @@ func (s *T) handleProduce(w http.ResponseWriter, r *http.Request) {
 // readMsg reads message from the HTTP request based on the Content-Type header.
 func (s *T) readMsg(r *http.Request) (sarama.Encoder, error) {
 	contentType := r.Header.Get(hdrContentType)
-	if contentType == "text/plain" || JsonTest.MatchString(contentType) {
+	if contentType == "text/plain" || jsonTest.MatchString(contentType) {
 		if _, ok := r.Header[hdrContentLength]; !ok {
 			return nil, errors.Errorf("missing %s header", hdrContentLength)
 		}


### PR DESCRIPTION
For example `application/vnd.docker.distribution.manifest.v2+json` from [Docker Registry](https://docs.docker.com/registry/notifications/).

Tested through https://github.com/Yolean/kubernetes-kafka/pull/198