### PR TITLE
Ignore what's after the mime-type in Content-Type 

### DIFF
--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -67,7 +67,7 @@ type T struct {
 
 func init() {
 	var err error
-	if jsonContentTypePattern, err = regexp.Compile("^application/(?:.*\\+)?json$"); err != nil {
+	if jsonContentTypePattern, err = regexp.Compile("^application/(?:.*\\+)?json(?:;.*)?$"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Allows for example `application/json; charset=UTF-8` as is POSTed by [JIRA webhooks](https://developer.atlassian.com/server/jira/platform/webhooks/).