### PR TITLE
Change default client ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+#### Version 0.17.0 (TBD)
+Implemented:
+* Default client ID was changed to `kp_<hostname>_<contain-id>` if running in a
+  docker container, otherwise `kp_<hostname>_<pid>`. If hostname cannot be
+  retrieved, then the client ID is `kp_<random-token>`.  
+
 #### Version 0.16.0 (2018-11-23)
 
 Implemented:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,13 +16,6 @@ type ConfigSuite struct{}
 
 var _ = Suite(&ConfigSuite{})
 
-func (s *ConfigSuite) TestGetIP(c *C) {
-	ip, err := getIP()
-	c.Assert(err, IsNil)
-	c.Assert(ip.String(), Matches, "\\d+.\\d+.\\d+.\\d+")
-	c.Assert(ip.String(), Not(Equals), "127.0.0.1")
-}
-
 func (s *ConfigSuite) TestFromYAMLNoProxies(c *C) {
 	// When
 	_, err := FromYAML([]byte(""))


### PR DESCRIPTION
Default client ID was changed to:
* `kp_<hostname>_<contain-id>` if running in a docker container;
* `kp_<hostname>_<pid>` if running on a host;
* `kp_<random-token>` if hostname cannot be determined.