### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -327,12 +327,12 @@ func DefaultApp(cluster string) *App {
 	return appCfg
 }
 
-// DefaultCluster returns configuration used by default.
+// DefaultProxy returns configuration used by default.
 func DefaultProxy() *Proxy {
 	return defaultProxyWithClientID(newClientID())
 }
 
-// FromYAML parses configuration from a YAML file and performs basic
+// FromYAMLFile parses configuration from a YAML file and performs basic
 // validation of parameters.
 func FromYAMLFile(filename string) (*App, error) {
 	configFile, err := os.Open(filename)

--- a/server/grpcsrv/grpcsrv.go
+++ b/server/grpcsrv/grpcsrv.go
@@ -54,7 +54,7 @@ func New(addr string, proxySet *proxy.Set) (*T, error) {
 	return &s, nil
 }
 
-// Starts triggers asynchronous gRPC server start. If it fails then the error
+// Start starts triggers asynchronous gRPC server start. If it fails then the error
 // will be sent down to `ErrorCh()`.
 func (s *T) Start() {
 	actor.Spawn(s.actDesc, &s.wg, func() {

--- a/server/httpsrv/httpsrv.go
+++ b/server/httpsrv/httpsrv.go
@@ -131,7 +131,7 @@ func New(addr string, proxySet *proxy.Set) (*T, error) {
 	return hs, nil
 }
 
-// Starts triggers asynchronous HTTP server start. If it fails then the error
+// Start starts triggers asynchronous HTTP server start. If it fails then the error
 // will be sent down to `ErrorCh()`.
 func (s *T) Start() {
 	actor.Spawn(s.actDesc, &s.wg, func() {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?