### PR TITLE
add configuration support for gRPC TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
 # Changelog
 
+#### Version 0.18.0 (TBD)
+
+Implemented:
+* [#167](https://github.com/mailgun/kafka-pixy/pull/167)
+  Add support for SSL/TLS connections in both gRPC and HTTP services.
+  Set both a certificate and key file in the configuration to take
+  advantage of this feature.
+  [Issue 160](https://github.com/mailgun/kafka-pixy/issues/54)
+
 #### Version 0.17.0 (TBD)
 Implemented:
 * Default client ID was changed to `kp_<hostname>_<contain-id>` if running in a
   docker container, otherwise `kp_<hostname>_<pid>`. If hostname cannot be
-  retrieved, then the client ID is `kp_<random-token>`.  
+  retrieved, then the client ID is `kp_<random-token>`.
 
 #### Version 0.16.0 (2018-11-23)
 
 Implemented:
-* [#156](https://github.com/mailgun/kafka-pixy/pull/156) 
+* [#156](https://github.com/mailgun/kafka-pixy/pull/156)
   [#151](https://github.com/mailgun/kafka-pixy/pull/151) Added formal support
   for Kafka versions up to v2.1.0.
 * [#155](https://github.com/mailgun/kafka-pixy/pull/155) When the last group
@@ -24,7 +33,7 @@ Implemented:
   network-level timeouts.
 
 Fixed:
-* [#54](https://github.com/mailgun/kafka-pixy/issues/54) Rebalancing fails due 
+* [#54](https://github.com/mailgun/kafka-pixy/issues/54) Rebalancing fails due
   to non existent topic.
 
 #### Version 0.15.0 (2018-03-30)
@@ -45,7 +54,7 @@ Fixed:
   topic stopped for a group.
 * [#123](https://github.com/mailgun/kafka-pixy/issues/123) Inexplicable offset
   manager timeouts.
-* [#124](https://github.com/mailgun/kafka-pixy/issues/124) Subscription to a 
+* [#124](https://github.com/mailgun/kafka-pixy/issues/124) Subscription to a
   topic fails indefinitely after ZooKeeper connection loss.
 * [#140](https://github.com/mailgun/kafka-pixy/issues/140) Offset manager keeps
   loosing connection with a broker.
@@ -142,7 +151,7 @@ This release aims to make getting started with Kafka-Pixy easier.
   `GET /topics/<>/consumers` easier to read.
 * By default services listens on 19092 port for incoming API requests and a
   unix domain socket is activated only if the `--unixAddr` command line
-  parameter is specified. 
+  parameter is specified.
 * By default a pid file is not created anymore. You need to explicitly specify
   `--pidFile` command line argument to get it created.
 * The source code was refactored into packages to make it easier to understand

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -362,6 +362,7 @@
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/status",
     "gopkg.in/check.v1",
     "gopkg.in/yaml.v2",

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ manage consumer group membership.
 **Warning**: Kafka-Pixy does not support wildcard subscriptions and therefore
 cannot coexist in a consumer group with clients using them. It should be
 possible to use other clients in the same consumer group as kafka-pixy instance
-if they subscribe to topics by their full names, but that **has never been 
+if they subscribe to topics by their full names, but that **has never been
 tested** so do that at your own risk.
- 
+
 If you are anxious to get started then [install](howto-install.md) Kafka-Pixy
 and proceed with a quick start guide for your weapon of choice:
 [Curl](quick-start-curl.md), [Python](quick-start-python.md), or [Golang](quick-start-golang.md).
 If you want to use some other language, then you still can use either of the
 guides for inspiration, but you would need to generate gRPC client stubs
 from [kafkapixy.proto](kafkapixy.proto) yourself (please refer to [gRPC documentation](http://www.grpc.io/docs/)
-for details). 
+for details).
 
 #### Key Features:
 
@@ -38,8 +38,8 @@ for details).
   by [Confluent](https://www.confluent.io/) clients do not need to explicitly
   create a consumer instance. When Kafka-Pixy gets a consume request for a
   group-topic pair for the first time, it automatically joins the group and
-  subscribes to the topic. When requests stop coming for longer than the 
-  [subscription timeout](https://www.confluent.io/) it cancels the subscription;    
+  subscribes to the topic. When requests stop coming for longer than the
+  [subscription timeout](https://www.confluent.io/) it cancels the subscription;
 - **At Least Once Guarantee**: The main feature of Kafka-Pixy is that
   it guarantees at-least-once message delivery. The guarantee is
   achieved via combination of synchronous production and explicit
@@ -116,7 +116,7 @@ strings, the value of the HTTP header must be Base 64-encoded.
  cluster   | yes | The name of a cluster to operate on. By default the cluster mentioned first in the `proxies` section of the config file is used.
  topic     |     | The name of a topic to produce to
  key       | yes | A string whose hash is used to determine a partition to produce to. By default a random partition is selected.
- msg       |  *  | Used only if the request content type is `x-www-form-urlencoded`. In other cases the request body is the message.  
+ msg       |  *  | Used only if the request content type is `x-www-form-urlencoded`. In other cases the request body is the message.
  sync      | yes | A flag (value is ignored) that makes Kafka-Pixy wait for all ISR to confirm write before sending a response back. By default a response is sent immediatelly after the request is received.
 
 By default the message is written to Kafka asynchronously, that is the
@@ -146,7 +146,7 @@ curl -X POST localhost:8080/topics/foo/messages?key=bar&sync \
 
 If the message is submitted asynchronously then the response will be an
 empty json object `{}`.
- 
+
 If the message is submitted synchronously then in case of success (HTTP
 status **200**) the response will be like:
 
@@ -206,7 +206,7 @@ If a Kafka-Pixy instance has not received consume requests for a topic for the d
 [subscription timeout](https://github.com/mailgun/kafka-pixy/blob/master/default.yaml#L139),
 then it unsubscribes from the topic, and the topic partitions are
 redistributed among Kafka-Pixy instances that are still consuming from it.
- 
+
 If there are no unread messages in the topic the request will block
 waiting for the duration of the [long polling timeout](https://github.com/mailgun/kafka-pixy/blob/master/default.yaml#L109).
 If there are no messages produced during this long poll waiting then the request
@@ -264,7 +264,7 @@ Acknowledges a previously consumed message.
  offset    |     | An offset of the acknowledged message.
 
 ### Get Offsets
- 
+
 ```
 GET /topics/<topic>/offsets
 GET /clusters/<cluster>/topics/<topic>/offsets
@@ -416,7 +416,7 @@ Returns topic configuration optionally with a list of partitions.
 
 ## Configuration
 
-Kafa-Pixy is designed to be very simple to run. It consists of a single
+Kafka-Pixy is designed to be very simple to run. It consists of a single
 executable that can be started just by passing a bunch of command line
 parameters to it - no configuration file needed.
 
@@ -442,6 +442,14 @@ Command line parameters that Kafka-Pixy accepts are listed below:
 
 You can run `kafka-pixy -help` to make it list all available command line
 parameters.
+
+### Security
+
+SSL/TLS can be configured on both the gRPC and HTTP servers by
+specifying a certificate and key file in the configuration. Both files
+must be specified in order to run with security enabled.
+
+If configured, both the gRPC and HTTP servers will run with TLS enabled.
 
 ## License
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,6 +116,6 @@ func (s *ConfigSuite) TestFromYAMLTLS(c *C) {
 
 	// Then
 	c.Assert(err, IsNil)
-	c.Assert(appCfg.AppTLS.CertPath, Equals, "/usr/local/etc/server.crt")
-	c.Assert(appCfg.AppTLS.KeyPath, Equals, "/usr/local/etc/server.key")
+	c.Assert(appCfg.TLS.CertPath, Equals, "/usr/local/etc/server.crt")
+	c.Assert(appCfg.TLS.KeyPath, Equals, "/usr/local/etc/server.key")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,3 +109,13 @@ func (s *ConfigSuite) TestFromYAMLFile(c *C) {
 	appCfg.Proxies["default"].ClientID = "ID"
 	c.Assert(appCfg, DeepEquals, expected)
 }
+
+func (s *ConfigSuite) TestFromYAMLTLS(c *C) {
+	// When
+	appCfg, err := FromYAMLFile("../testdata/tls.yaml")
+
+	// Then
+	c.Assert(err, IsNil)
+	c.Assert(appCfg.AppTLS.CertPath, Equals, "/usr/local/etc/server.crt")
+	c.Assert(appCfg.AppTLS.KeyPath, Equals, "/usr/local/etc/server.key")
+}

--- a/default.yaml
+++ b/default.yaml
@@ -177,16 +177,13 @@ proxies:
       # topic by a group in absence of requests to from the consumer group.
       subscription_timeout: 15s
 
-# Configuration for securely accessing the gRPC and web serversx
+# Configuration for securely accessing the gRPC and web servers
 tls:
 
-  # gRPC specific configuration
-  grpc:
+  # Path to the server certificate file.
+  # Required if using gRPC SSL/TLS or HTTPS.
+  # certificate_path: /usr/local/etc/server.crt
 
-    # Path to the server certificate file.
-    # Required if using gRPC SSL/TLS.
-    # certificate_path: /usr/local/etc/server.crt
-
-    # Path to the server certificate key file.
-    # Required if using gRPC SSL/TLS.
-    # key_path: /usr/local/etc/server.key
+  # Path to the server certificate key file.
+  # Required if using gRPC SSL/TLS or HTTPS.
+  # key_path: /usr/local/etc/server.key

--- a/server/grpcsrv/grpcsrv.go
+++ b/server/grpcsrv/grpcsrv.go
@@ -36,13 +36,14 @@ type T struct {
 }
 
 // New creates a gRPC server instance.
-func New(addr string, proxySet *proxy.Set) (*T, error) {
+func New(addr string, proxySet *proxy.Set, srvOpts ...grpc.ServerOption) (*T, error) {
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create listener")
 	}
 
-	grpcSrv := grpc.NewServer(grpc.MaxMsgSize(maxRequestSize))
+	opts := append(srvOpts, grpc.MaxMsgSize(maxRequestSize))
+	grpcSrv := grpc.NewServer(opts...)
 	s := T{
 		actDesc:  actor.Root().NewChild(fmt.Sprintf("grpc://%s", addr)),
 		listener: listener,

--- a/service/service.go
+++ b/service/service.go
@@ -54,7 +54,7 @@ func Spawn(cfg *config.App) (*T, error) {
 		s.servers = append(s.servers, grpcSrv)
 	}
 	if cfg.TCPAddr != "" {
-		tcpSrv, err := httpsrv.New(cfg.TCPAddr, proxySet)
+		tcpSrv, err := httpsrv.New(cfg.TCPAddr, proxySet, cfg.TLS.CertPath, cfg.TLS.KeyPath)
 		if err != nil {
 			s.stopProxies()
 			return nil, errors.Wrap(err, "failed to start TCP socket based HTTP API server")
@@ -62,7 +62,7 @@ func Spawn(cfg *config.App) (*T, error) {
 		s.servers = append(s.servers, tcpSrv)
 	}
 	if cfg.UnixAddr != "" {
-		unixSrv, err := httpsrv.New(cfg.UnixAddr, proxySet)
+		unixSrv, err := httpsrv.New(cfg.UnixAddr, proxySet, "", "")
 		if err != nil {
 			s.stopProxies()
 			return nil, errors.Wrapf(err, "failed to start Unix socket based HTTP API server")

--- a/service/service.go
+++ b/service/service.go
@@ -41,7 +41,12 @@ func Spawn(cfg *config.App) (*T, error) {
 	proxySet := proxy.NewSet(s.proxies, s.proxies[cfg.DefaultCluster])
 
 	if cfg.GRPCAddr != "" {
-		grpcSrv, err := grpcsrv.New(cfg.GRPCAddr, proxySet)
+		securityOpts, err := cfg.GRPCSecurityOpts()
+		if err != nil {
+			s.stopProxies()
+			return nil, errors.Wrap(err, "failed to configure gRPC security")
+		}
+		grpcSrv, err := grpcsrv.New(cfg.GRPCAddr, proxySet, securityOpts...)
 		if err != nil {
 			s.stopProxies()
 			return nil, errors.Wrap(err, "failed to start gRPC server")

--- a/testdata/tls.yaml
+++ b/testdata/tls.yaml
@@ -177,16 +177,13 @@ proxies:
       # topic by a group in absence of requests to from the consumer group.
       subscription_timeout: 15s
 
-# Configuration for securely accessing the gRPC and web serversx
+# Configuration for securely accessing the gRPC and web servers
 tls:
 
-  # gRPC specific configuration
-  grpc:
+  # Path to the server certificate file.
+  # Required if using gRPC SSL/TLS or HTTPS.
+  certificate_path: /usr/local/etc/server.crt
 
-    # Path to the server certificate file.
-    # Required if using gRPC SSL/TLS.
-    certificate_path: /usr/local/etc/server.crt
-
-    # Path to the server certificate key file.
-    # Required if using gRPC SSL/TLS.
-    key_path: /usr/local/etc/server.key
+  # Path to the server certificate key file.
+  # Required if using gRPC SSL/TLS or HTTPS.
+  key_path: /usr/local/etc/server.key

--- a/testdata/tls.yaml
+++ b/testdata/tls.yaml
@@ -185,8 +185,8 @@ tls:
 
     # Path to the server certificate file.
     # Required if using gRPC SSL/TLS.
-    # certificate_path: /usr/local/etc/server.crt
+    certificate_path: /usr/local/etc/server.crt
 
     # Path to the server certificate key file.
     # Required if using gRPC SSL/TLS.
-    # key_path: /usr/local/etc/server.key
+    key_path: /usr/local/etc/server.key


### PR DESCRIPTION
this adds support for gRPC TLS in the configuration and in the application.

i think there's an issue in the current `FromYAML` method in that it doesn't actually read the `grpc_address` field, it just uses the one from `defaultApp`. so i'm not sure if that's worth fixing alongside this.

anyway, let me know if you have any feedback, i'd also be happy to add HTTPS security if you'd like to see that before merging. 