### PR TITLE
Use the nomad alloc id if it exists in the environment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -655,6 +655,13 @@ func defaultProxyWithClientID(clientID string) *Proxy {
 // newClientID creates a unique id that identifies this particular Kafka-Pixy
 // in both Kafka and ZooKeeper.
 func newClientID() string {
+	if nomad := os.Getenv("NOMAD_ALLOC_ID"); nomad != "" {
+		parts := strings.Split(nomad, "-")
+		if idx := os.Getenv("NOMAD_ALLOC_INDEX"); idx != "" {
+			return "kp_nomad_" + parts[0] + "_" + idx
+		}
+		return "kp_nomad_" + parts[0]
+	}
 	hostname, err := os.Hostname()
 	if err != nil {
 		token := make([]byte, 4)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -153,4 +154,19 @@ func (s *ConfigSuite) TestFromYAMLKafkaTLS(c *C) {
 	c.Assert(kafkaCfg.ClientCertFile, Equals, "../testdata/client.crt")
 	c.Assert(kafkaCfg.ClientCertKeyFile, Equals, "../testdata/client.key")
 	c.Assert(kafkaCfg.InsecureSkipVerify, Equals, false)
+}
+
+func (s *ConfigSuite) TestClientIDFromNomad(c *C) {
+	// When
+	os.Setenv("NOMAD_ALLOC_ID", "b313e983-c906-49df-b5f7-f6fbc59b3297")
+	os.Setenv("NOMAD_ALLOC_INDEX", "0")
+	defer func() {
+		os.Setenv("NOMAD_ALLOC_ID", "")
+		os.Setenv("NOMAD_ALLOC_INDEX", "")
+	}()
+	appCfg, err := FromYAMLFile("../default.yaml")
+
+	// Then
+	c.Assert(err, IsNil)
+	c.Assert("kp_nomad_b313e983_0", Equals, appCfg.Proxies["default"].ClientID)
 }


### PR DESCRIPTION
## Purpose
When attempting to identify a running kp instance using the registered client-id, it is useful to track that id back to running nomad alloc instance.