### PR TITLE
PIP-1929: `consumer/multiplexer` now only round-robins partitions

### DIFF
--- a/cmd/kafka-pixy-cli/main.go
+++ b/cmd/kafka-pixy-cli/main.go
@@ -345,7 +345,7 @@ func ListConsumers(parser *args.ArgParser, cast interface{}) (int, error) {
 		return 1, nil
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*60)
 	resp, err := client.ListConsumers(ctx, &pb.ListConsumersRq{
 		Group: opts.String("group"),
 		Topic: opts.String("topic"),

--- a/cmd/kafka-pixy-cli/main.go
+++ b/cmd/kafka-pixy-cli/main.go
@@ -179,7 +179,7 @@ func printOffsets(opts *args.Options, client pb.KafkaPixyClient) (int, error) {
 			Lag:   lag,
 		}
 
-		data, err := json.MarshalIndent(offset, "", "    ")
+		data, err := json.MarshalIndent(&offset, "", "    ")
 		if err != nil {
 			return 1, errors.Wrap(err, "during JSON marshal")
 		}

--- a/consumer/multiplexer/multiplexer.go
+++ b/consumer/multiplexer/multiplexer.go
@@ -248,27 +248,29 @@ reset:
 			}
 		}
 
+		if isAtLeastOneAvailable {
+			continue
+		}
+
 		// If none of the inputs has a message available, then wait until
 		// a message is fetched on any of them or a stop signal is received.
-		if !isAtLeastOneAvailable {
-			idx, value, _ := reflect.Select(selectCases)
-			// Check if it is a stop signal.
-			if idx == inputCount {
-				return
-			}
+		idx, value, _ := reflect.Select(selectCases)
+		// Check if it is a stop signal.
+		if idx == inputCount {
+			return
+		}
 
-			// Block until the output reads the next message of the selected input
-			// or a stop signal is received.
-			msg := value.Interface().(consumer.Message)
-			select {
-			case m.output.Messages() <- msg:
-			case <-m.stopCh:
-				// Store the message in case stopCh eval is due to a WireUp() call, and we
-				// need to provide this message later
-				m.sortedIns[idx].msgOk = true
-				m.sortedIns[idx].msg = msg
-				return
-			}
+		// Block until the output reads the next message of the selected input
+		// or a stop signal is received.
+		msg := value.Interface().(consumer.Message)
+		select {
+		case m.output.Messages() <- msg:
+		case <-m.stopCh:
+			// Store the message in case stopCh eval is due to a WireUp() call, and we
+			// need to provide this message later
+			m.sortedIns[idx].msgOk = true
+			m.sortedIns[idx].msg = msg
+			return
 		}
 	}
 }

--- a/consumer/multiplexer/multiplexer.go
+++ b/consumer/multiplexer/multiplexer.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mailgun/kafka-pixy/actor"
@@ -20,7 +21,7 @@ type T struct {
 	spawnInFn SpawnInFn
 	inputs    map[int32]*input
 	output    Out
-	isRunning bool
+	isRunning int64
 	stopCh    chan none.T
 	wg        sync.WaitGroup
 
@@ -75,7 +76,7 @@ type input struct {
 // IsRunning returns `true` if multiplexer is running pumping events from the
 // inputs to the output.
 func (m *T) IsRunning() bool {
-	return m.isRunning
+	return atomic.LoadInt64(&m.isRunning) == 1
 }
 
 // IsSafe2Stop returns true if it is safe to stop all of the multiplexer
@@ -163,14 +164,14 @@ func (m *T) Stop() {
 
 func (m *T) start() {
 	actor.Spawn(m.actDesc, &m.wg, m.run)
-	m.isRunning = true
+	atomic.StoreInt64(&m.isRunning, 1)
 }
 
 func (m *T) stopIfRunning() {
-	if m.isRunning {
+	if atomic.LoadInt64(&m.isRunning) == 1 {
 		m.stopCh <- none.V
 		m.wg.Wait()
-		m.isRunning = false
+		atomic.StoreInt64(&m.isRunning, 0)
 	}
 }
 
@@ -197,31 +198,59 @@ reset:
 	}
 	selectCases[inputCount] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(m.stopCh)}
 
-	inputIdx := -1
+	// NOTE: When Stop() or WireUp() occurs the current `msg` might not
+	// be delivered before `case <-m.stopCh` is evaluated. In this case
+	// we store the message in m.sortedIns[X].msg for possible delivery
+	// on the next iteration after a `reset` has occurred.
+
+	// TODO: It is possible that an unconfirmed message keep kafka-pixy from releasing a
+	//   partition during a re-balance? I think this situation also existed with
+	//   the previous version of this code, so... should be okay?
+	//   It's possible that KP will not shutdown the multiplexer until all outstanding
+	//   messages are acknowledged, so this might not be a problem at all?
+
 	for {
-		// Collect next messages from inputs that have them available.
 		isAtLeastOneAvailable := false
 		for _, in := range m.sortedIns {
+
+			// If we have a message to deliver from a previous iteration,
+			// and we were interrupted by a WireUp(), send that message first.
 			if in.msgOk {
 				isAtLeastOneAvailable = true
+
+				select {
+				case m.output.Messages() <- in.msg:
+					in.msgOk = false
+				case <-m.stopCh:
+					return
+				}
 				continue
 			}
+
 			select {
 			case msg, ok := <-in.Messages():
 				// If a channel of an input is closed, then the input should be
 				// removed from the list of multiplexed inputs.
 				if !ok {
-					m.actDesc.Log().Infof("input channel closed: partition=%d", in.partition)
 					delete(m.inputs, in.partition)
 					m.refreshSortedIns()
 					goto reset
 				}
-				in.msg = msg
-				in.msgOk = true
 				isAtLeastOneAvailable = true
+
+				select {
+				case m.output.Messages() <- msg:
+				case <-m.stopCh:
+					// Store the message in case stopCh eval is due to a WireUp() call, and we
+					// need to provide this message later
+					in.msgOk = true
+					in.msg = msg
+					return
+				}
 			default:
 			}
 		}
+
 		// If none of the inputs has a message available, then wait until
 		// a message is fetched on any of them or a stop signal is received.
 		if !isAtLeastOneAvailable {
@@ -230,18 +259,19 @@ reset:
 			if idx == inputCount {
 				return
 			}
-			m.sortedIns[idx].msg = value.Interface().(consumer.Message)
-			m.sortedIns[idx].msgOk = true
-		}
-		// At this point there is at least one message available.
-		inputIdx = selectInput(inputIdx, m.sortedIns)
-		// Block until the output reads the next message of the selected input
-		// or a stop signal is received.
-		select {
-		case <-m.stopCh:
-			return
-		case m.output.Messages() <- m.sortedIns[inputIdx].msg:
-			m.sortedIns[inputIdx].msgOk = false
+
+			// Block until the output reads the next message of the selected input
+			// or a stop signal is received.
+			msg := value.Interface().(consumer.Message)
+			select {
+			case m.output.Messages() <- msg:
+			case <-m.stopCh:
+				// Store the message in case stopCh eval is due to a WireUp() call, and we
+				// need to provide this message later
+				m.sortedIns[idx].msgOk = true
+				m.sortedIns[idx].msg = msg
+				return
+			}
 		}
 	}
 }
@@ -267,33 +297,4 @@ func hasPartition(partition int32, partitions []int32) bool {
 		return false
 	}
 	return partitions[0] <= partition && partition <= partitions[count-1]
-}
-
-// selectInput picks an input that should be multiplexed next. It prefers the
-// inputs with the largest lag. If there is more then one input with the same
-// largest lag, then it picks the one that has index following prevSelectedIdx.
-func selectInput(prevSelectedIdx int, sortedIns []*input) int {
-	maxLag := int64(-1)
-	selectedIdx := -1
-	for i, input := range sortedIns {
-		if !input.msgOk {
-			continue
-		}
-		lag := input.msg.HighWaterMark - input.msg.Offset
-		if lag > maxLag {
-			maxLag = lag
-			selectedIdx = i
-			continue
-		}
-		if lag < maxLag {
-			continue
-		}
-		if selectedIdx > prevSelectedIdx {
-			continue
-		}
-		if i > prevSelectedIdx {
-			selectedIdx = i
-		}
-	}
-	return selectedIdx
 }

--- a/consumer/multiplexer/multiplexer.go
+++ b/consumer/multiplexer/multiplexer.go
@@ -201,13 +201,10 @@ reset:
 	// NOTE: When Stop() or WireUp() occurs the current `msg` might not
 	// be delivered before `case <-m.stopCh` is evaluated. In this case
 	// we store the message in m.sortedIns[X].msg for possible delivery
-	// on the next iteration after a `reset` has occurred.
-
-	// TODO: It is possible that an unconfirmed message keep kafka-pixy from releasing a
-	//   partition during a re-balance? I think this situation also existed with
-	//   the previous version of this code, so... should be okay?
-	//   It's possible that KP will not shutdown the multiplexer until all outstanding
-	//   messages are acknowledged, so this might not be a problem at all?
+	// on the next iteration after a `reset` has occurred. The exception
+	// to this is if KP shuts down the multiplexer while we have a message
+	// waiting, this messsage will be lost, however the offset tracker should
+	// eventually retry that message again some time in the fiture.
 
 	for {
 		isAtLeastOneAvailable := false


### PR DESCRIPTION
### Implementation Notes
When Stop() or WireUp() occurs the current `msg` might not
be delivered before `case <-m.stopCh` is evaluated. In this case
we store the message in `m.sortedIns[X].msg` for possible delivery
on the next iteration after a `reset` has occurred.

It is possible that an unconfirmed message keep kafka-pixy from releasing a
partition during a re-balance? I think this situation also existed with
the previous version of this code, so... should be okay?
It's possible that KP will not shutdown the multiplexer until all outstanding
messages are acknowledged, so this might not be a problem at all?
